### PR TITLE
Updating pull_toolchain()

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,18 +58,18 @@ pull_toolchain(){
 	cd ${temp_root_dir}/${toolchain_dir}
 	ldconfig
 	if [ $(getconf WORD_BIT) = '32' ] && [ $(getconf LONG_BIT) = '64' ] ; then
-		wget http://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabi/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz &&\
-		tar xvJf gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz
-		if [ ! -d ${temp_root_dir}/${toolchain_dir}/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi ]; then
+		wget http://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabi/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabi.tar.xz &&\
+		tar xvJf gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabi.tar.xz
+		if [ ! -d ${temp_root_dir}/${toolchain_dir}/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabi ]; then
 			echo "Error:pull toolchain failed"
 	    		exit 0
 		else			
 			echo "pull buildroot ok"
 		fi
 	else
-	 	wget http://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabi/gcc-linaro-7.4.1-2019.02-i686_arm-linux-gnueabi.tar.xz &&\
-		tar xvJf gcc-linaro-7.4.1-2019.02-i686_arm-linux-gnueabi.tar.xz
-		if [ ! -d ${temp_root_dir}/${toolchain_dir}/gcc-linaro-7.4.1-2019.02-i686_arm-linux-gnueabi ]; then
+	 	wget http://releases.linaro.org/components/toolchain/binaries/latest-7/gcc-linaro-7.5.0-2019.12-i686_arm-linux-gnueabi.tar.xz &&\
+		tar xvJf gcc-linaro-7.5.0-2019.12-i686_arm-linux-gnueabi.tar.xz
+		if [ ! -d ${temp_root_dir}/${toolchain_dir}/gcc-linaro-7.5.0-2019.12-i686_arm-linux-gnueabi ]; then
 			echo "Error:pull toolchain failed"
 	    		exit 0
 		else			


### PR DESCRIPTION
#3 
After checking http://releases.linaro.org/components/toolchain/binaries/latest-7/arm-linux-gnueabi/

the version 7.4 is replace by 7.5. So, the script is updated to prevent 404 error on execution.